### PR TITLE
Docs: plan markdown typography variants

### DIFF
--- a/docs/CRs/MDT-173-markdown-typography-variants.md
+++ b/docs/CRs/MDT-173-markdown-typography-variants.md
@@ -1,0 +1,210 @@
+---
+code: MDT-173
+status: In Progress
+dateCreated: 2026-05-18T14:33:40.639Z
+type: Feature Enhancement
+priority: High
+---
+
+# Implement markdown typography variants
+
+## 1. Description
+
+### Requirements Scope
+`full`
+
+### Problem
+- `src/components/MarkdownContent/index.tsx` applies one default `prose prose-sm max-w-none` class to all primary markdown reading surfaces.
+- `src/styles/prose.css` styles code, tables, anchors, Mermaid, and Wireloom but does not define durable typography rhythm for headings, paragraphs, lists, blockquotes, tables, or reading-width variants.
+- `src/components/DocumentsView/MarkdownViewer.tsx` renders full documents without a document-specific prose measure, causing wide desktop lines and broken mobile reading with the persistent navigation pane.
+- `src/components/TicketViewer/index.tsx` renders ticket markdown without an explicit compact ticket prose contract, so section rhythm and timestamp spacing are implicit.
+
+### Affected Artifacts
+- `src/components/MarkdownContent/index.tsx` - prose variant class contract and default behavior.
+- `src/styles/prose.css` - markdown typography, rich content styling, and prose variants.
+- `src/components/DocumentsView/MarkdownViewer.tsx` - document prose variant usage and viewer content measure.
+- `src/components/DocumentsView/documents-view.css` - document viewer layout and responsive reading behavior.
+- `src/components/TicketViewer/index.tsx` - ticket prose variant usage and timestamp/content spacing.
+- `src/components/MarkdownContent/*.test.tsx` - renderer and class contract coverage.
+- `src/components/DocumentsView/*.test.tsx` - document viewer variant and responsive behavior coverage.
+- `src/components/TicketViewer/*.test.tsx` - ticket viewer variant and timestamp/content coverage.
+- `docs/design/surfaces/markdown-content.spec.md` - source UX contract.
+- `docs/design/surfaces/markdown-content.mockups.md` - source UX review artifact.
+
+### Scope
+- Changes: implement the markdown typography variants defined by `docs/design/surfaces/markdown-content.spec.md`.
+- Changes: apply the document variant in Documents View and the ticket variant in Ticket Viewer.
+- Changes: improve markdown styling for headings, paragraphs, lists, task lists, links, inline code, code blocks, tables, blockquotes, rules, images, Mermaid fallback, and Wireloom fallback.
+- Changes: make Documents View mobile reading single-pane or otherwise prevent the persistent tree from squeezing the markdown preview.
+- Unchanged: markdown parsing pipeline, SmartLink classification, Mermaid rendering logic, Wireloom rendering logic, ticket data model, document file discovery, and backend APIs.
+
+## 2. Decision
+
+### Chosen Approach
+Add scoped `.prose--document`, `.prose--ticket`, and `.prose--compact` modifiers in `src/styles/prose.css` and apply them from existing viewer components.
+
+### Rationale
+- `src/STYLING.md` already assigns prose and markdown rendering to `src/styles/prose.css`, so variant classes fit the existing CSS architecture.
+- `MarkdownContent` remains the shared rendering component while viewers choose density through `className` composition.
+- `DocumentsView` and `TicketViewer` need different reading density, so a single global `.prose` rhythm would regress one surface.
+- Tokenized CSS keeps dark mode and code-theme behavior aligned with `src/styles/design-tokens.css`.
+- Viewer-owned layout remains separate from prose internals, matching the `STYLING.md` component boundary.
+
+## 3. Alternatives Considered
+
+| Approach | Key Difference | Why Rejected |
+|----------|----------------|--------------|
+| **Chosen Approach** | Add scoped prose modifier classes and apply them from viewers | **ACCEPTED** - Reuses `prose.css` and keeps viewer layout separate |
+| Global `.prose` rewrite only | One rhythm for every markdown consumer | Rejected because documents and ticket modals need different density |
+| Inline Tailwind overrides in each viewer | Viewer components own markdown descendant styling | Rejected because markdown internals become duplicated and hard to keep tokenized |
+| Add a new markdown renderer component per surface | Split renderer by consumer | Rejected because parsing, SmartLink, Mermaid, and Wireloom behavior should stay shared |
+| Defer mobile layout | Only improve desktop typography | Rejected because live review showed Documents View mobile reading is currently squeezed and overlapping |
+
+## 4. Artifact Specifications
+
+### New Artifacts
+
+| Artifact | Type | Purpose |
+|----------|------|---------|
+| None | n/a | Reuse existing renderer, CSS, viewer, and test files |
+
+### Modified Artifacts
+
+| Artifact | Change Type | Modification |
+|----------|-------------|--------------|
+| `src/styles/prose.css` | CSS expanded | Add `.prose--document`, `.prose--ticket`, `.prose--compact`, and tokenized descendant styles |
+| `src/components/MarkdownContent/index.tsx` | Class contract updated | Preserve default rendering while allowing stable variant classes from consumers |
+| `src/components/DocumentsView/MarkdownViewer.tsx` | Variant applied | Render document markdown with `.prose--document` |
+| `src/components/DocumentsView/documents-view.css` | Layout updated | Add readable measure and responsive single-pane preview behavior |
+| `src/components/TicketViewer/index.tsx` | Variant applied | Render ticket markdown with `.prose--ticket` and avoid timestamp overlap |
+| `src/components/MarkdownContent/useHtmlParser.ts` | Link focus compatibility checked | Preserve SmartLink replacement and heading-anchor behavior |
+| `src/components/MarkdownContent/useMarkdownProcessor.ts` | Pipeline compatibility checked | Preserve markdown-it plugin behavior |
+| `src/components/MarkdownContent/useMarkdownProcessor.test.ts` | Tests updated | Verify markdown output remains compatible with new prose classes |
+| `src/components/DocumentsView/MarkdownViewer.test.tsx` | Tests updated | Verify document prose variant is applied |
+| `src/components/TicketViewer` tests | Tests updated | Verify ticket prose variant is applied |
+| `tests/e2e` relevant document/ticket specs | E2E updated | Cover desktop and mobile markdown reading surfaces if existing tests fit |
+
+### Integration Points
+
+| From | To | Interface |
+|------|----|-----------|
+| `MarkdownViewer` | `MarkdownContent` | `className` includes `.prose--document` |
+| `TicketViewer` | `MarkdownContent` | `className` includes `.prose--ticket` |
+| `MarkdownContent` | `useMarkdownProcessor` | Existing markdown string to sanitized/rendered HTML pipeline |
+| `MarkdownContent` | `SmartLink` | Existing anchor replacement through `getHtmlParserOptions()` |
+| `prose.css` | `design-tokens.css` | `--foreground`, `--muted-foreground`, `--primary`, `--border`, `--code-*`, `--ring` |
+| Documents View layout | TableOfContents | Mobile ToC must not cover active reading content by default |
+
+### Key Patterns
+- CSS modifier pattern: `.prose--document`, `.prose--ticket`, `.prose--compact` follow `src/STYLING.md` structural modifier guidance.
+- Tokenized theme pattern: markdown colors use existing CSS variables from `src/styles/design-tokens.css`.
+- Viewer boundary pattern: pane padding, scrolling, and mobile layout stay in viewer CSS; markdown descendants stay in `prose.css`.
+- Shared renderer pattern: `MarkdownContent` keeps one parsing/rendering pipeline for tickets and documents.
+- Reading measure pattern: document prose targets about `72ch`; tablet two-pane layout is allowed only when the prose column remains at least `48ch`.
+- Word wrapping pattern: long links, file paths, and identifiers may wrap, but normal words must not break letter-by-letter.
+
+## 5. Acceptance Criteria
+
+### Functional
+- [ ] `src/styles/prose.css` defines `.prose--document`, `.prose--ticket`, and `.prose--compact` modifiers.
+- [ ] Document prose body text reads at 15-16px with line-height near 1.65.
+- [ ] Ticket prose body text reads at 14-15px with line-height near 1.55-1.65.
+- [ ] `src/styles/prose.css` defines explicit markdown rhythm for headings, paragraphs, lists, task lists, blockquotes, horizontal rules, links, inline code, code blocks, tables, and images.
+- [ ] Task-list checkboxes align with the first text baseline and do not add extra left jitter.
+- [ ] Long links, file paths, and identifiers wrap without forcing normal words to break letter-by-letter.
+- [ ] `src/styles/prose.css` uses theme tokens for prose text, links, borders, code, selection, fallback Wireloom states, and focus treatment.
+- [ ] Markdown links expose hover and keyboard focus treatment using `--primary` and `--ring`.
+- [ ] `src/components/DocumentsView/MarkdownViewer.tsx` renders markdown with the document prose variant.
+- [ ] Documents View constrains document reading width while allowing tables, diagrams, and code blocks to scroll inside the viewer.
+- [ ] Documents View mobile preview does not keep a persistent tree beside the markdown content.
+- [ ] Documents View mobile preview does not overlap the first heading with timestamp, controls, or ToC.
+- [ ] `src/components/TicketViewer/index.tsx` renders markdown with the ticket prose variant.
+- [ ] Ticket Viewer keeps compact ticket section rhythm and prevents timestamp overlap with the first rendered heading or paragraph.
+- [ ] SmartLink, heading anchors, Mermaid diagrams, Wireloom blocks, images, and syntax-highlighted code still render after the styling changes.
+
+### Non-Functional
+- [ ] Styling follows `src/STYLING.md` class taxonomy and CSS location rules.
+- [ ] No markdown typography rules are added to `src/styles/base.css` except existing global heading defaults.
+- [ ] No backend, ticket model, document discovery, or markdown parsing behavior changes are introduced.
+- [ ] Dark mode keeps readable contrast for prose, links, code blocks, tables, blockquotes, Mermaid fallback, and Wireloom fallback.
+- [ ] Layout changes do not create page-level horizontal scrolling on desktop or mobile.
+
+### Testing
+- Unit: `MarkdownContent` or consumer tests verify document and ticket variant class application.
+- Unit: markdown rendering tests verify headings, links, task lists, code blocks, tables, images, Mermaid, and Wireloom output remain present.
+- Unit: Documents View tests verify selected markdown uses document prose and frontmatter still renders above body.
+- Unit: Ticket Viewer tests verify selected ticket content uses ticket prose and loading/error states still render.
+- E2E or Playwright: desktop Documents View screenshot verifies readable document measure and no text/control overlap.
+- E2E or Playwright: mobile Documents View screenshot verifies preview is not squeezed by persistent navigation and ToC does not cover initial reading position.
+- E2E or Playwright: Ticket Viewer screenshot verifies compact prose and timestamp placement.
+
+## 6. Verification
+
+### By CR Type
+- Feature: `src/styles/prose.css` contains the three prose variants, density targets, reading-measure rules, and tokenized markdown descendant styles.
+- Feature: Documents View and Ticket Viewer call `MarkdownContent` with the expected prose variant class names.
+- Feature: unit tests covering viewer class contracts pass.
+- Feature: Playwright visual checks for desktop document, mobile document, and ticket viewer pass without overlap or page-level horizontal scroll.
+
+### Metrics
+- Verify artifacts exist and tests pass; no performance metric is targeted by this CR.
+
+## 7. Deployment
+
+### Simple Changes
+- Deploy as a normal frontend change.
+- No database migration required.
+- No backend configuration required.
+- Rollback by reverting the frontend styling and viewer class changes.
+
+## 8. Implementation Plan
+
+### Phase 1: Prose CSS Foundation
+- Modify `src/styles/prose.css`.
+- Add `.prose--document`, `.prose--ticket`, and `.prose--compact`.
+- Move markdown rhythm into `.prose` descendants, not `src/styles/base.css`.
+- Define paragraph, heading, list, task-list, blockquote, horizontal-rule, table, image, link, inline-code, and code-block styles.
+- Replace hard-coded Wireloom pending/error fallback colors with existing theme tokens.
+- Keep Mermaid and Wireloom artifact behavior scrollable inside the prose container.
+
+### Phase 2: Viewer Integration
+- Modify `src/components/DocumentsView/MarkdownViewer.tsx`.
+- Pass `className="prose prose--document max-w-none dark:prose-invert"` or equivalent class composition to `MarkdownContent`.
+- Modify `src/components/TicketViewer/index.tsx`.
+- Pass `className="prose prose--ticket max-w-none dark:prose-invert"` or equivalent class composition to `MarkdownContent`.
+- Keep `headerLevelStart={3}` behavior in Ticket Viewer unchanged.
+- Preserve existing frontmatter disclosure placement above document markdown.
+
+### Phase 3: Documents View Layout
+- Modify `src/components/DocumentsView/documents-view.css`.
+- Add a readable document content measure around `72ch` without blocking wide artifacts from scrolling.
+- Ensure tablet two-pane layout is used only when the prose column remains at least `48ch`.
+- Change mobile Documents View so preview mode is not squeezed beside a persistent navigation tree.
+- Ensure timestamp, toolbar controls, and ToC do not overlap the first heading or first paragraph.
+
+### Phase 4: Ticket Viewer Layout
+- Keep Ticket Viewer content compact inside the modal.
+- Ensure the floating timestamp does not cover the first rendered heading or paragraph.
+- Preserve subdocument loading and error states.
+- Preserve document tab behavior and ToC behavior.
+
+### Phase 5: Unit Tests
+- Update `src/components/DocumentsView/MarkdownViewer.test.tsx` to assert document prose variant class usage.
+- Add or update Ticket Viewer tests to assert ticket prose variant class usage.
+- Update markdown rendering tests to confirm headings, task lists, links, code blocks, tables, images, Mermaid, and Wireloom output still render.
+- Keep existing SmartLink replacement tests passing.
+
+### Phase 6: Visual Verification
+- Run frontend validation for changed TypeScript files.
+- Run focused unit tests for MarkdownContent, Documents View, and Ticket Viewer.
+- Run Playwright checks for:
+  - desktop Documents View reading measure;
+  - mobile Documents View preview without tree squeeze or overlap;
+  - Ticket Viewer timestamp and compact prose layout.
+- Capture screenshots for the three visual checks when manually reviewing.
+
+### Phase 7: Implementation Guardrails
+- Do not change markdown-it plugins, preprocessing, SmartLink classification, Mermaid rendering logic, or Wireloom rendering logic.
+- Do not add markdown typography rules to `src/styles/base.css`.
+- Do not introduce backend changes.
+- Do not solve unrelated Documents View navigation behavior beyond the mobile reading requirement in this CR.

--- a/docs/design/surfaces/documents-view-file-updates.mockups.md
+++ b/docs/design/surfaces/documents-view-file-updates.mockups.md
@@ -4,6 +4,7 @@ Related spec: `documents-view-file-updates.spec.md`
 
 Shared navigation shell: `documents-view-navigation.mockups.md`.
 Filename tab states: `document-filename-tabs.mockups.md`.
+Markdown typography states: `markdown-content.mockups.md`.
 
 Use that mockup for the full sidebar/header/tree contract. This file only repeats sidebar detail when the update state changes the tree itself.
 
@@ -29,6 +30,7 @@ window "Documents View — Default":
 annotation "Sidebar composition is owned by documents-view-navigation.mockups.md" target="nav-context" position=bottom
 annotation "Shared floating relative timestamp, not an inline date row" target="floating-timestamp" position=top
 annotation "Valid leading frontmatter is collapsed above the rendered markdown body" target="frontmatter-collapsed" position=right
+annotation "Markdown body uses markdown-content.spec.md document variant" target="doc-heading" position=right
 ```
 
 ## Frontmatter Expanded

--- a/docs/design/surfaces/documents-view-file-updates.spec.md
+++ b/docs/design/surfaces/documents-view-file-updates.spec.md
@@ -35,6 +35,7 @@ DocumentsLayout
 | FileTree | `src/components/DocumentsView/FileTree.tsx` | — | when documents are configured |
 | DocumentFilenameTabs | `src/components/DocumentsView/DocumentFilenameTabs.tsx` | `document-filename-tabs.spec.md` | when selected markdown file belongs to a filename group |
 | MarkdownViewer | `src/components/DocumentsView/MarkdownViewer.tsx` | this spec | when a file is selected |
+| MarkdownContent | `src/components/MarkdownContent/index.tsx` | `markdown-content.spec.md` | when markdown body renders |
 | PathSelector | `src/components/DocumentsView/PathSelector.tsx` | — | when no document paths are configured |
 
 ## Source files
@@ -168,6 +169,8 @@ Documents should not write date frontmatter automatically. For configured docume
 - The target/crosshair button sits in the sidebar header control cluster, between sort direction and path configuration.
 - The target/crosshair button scrolls the tree to the active document and expands collapsed ancestor folders.
 - Timestamp/status appears in the existing floating timestamp area at the top-right of the viewer.
+- Markdown body uses the `document` typography variant from `markdown-content.spec.md`.
+- The document prose column should keep a readable measure around `72ch`; wide artifacts scroll inside the viewer.
 - Deleted-file state uses the viewer empty-state area, not a modal.
 - No toast is required for selected-file refresh; the viewer itself shows the state.
 - Non-selected file updates should not interrupt reading.
@@ -176,8 +179,10 @@ Documents should not write date frontmatter automatically. For configured docume
 
 | Breakpoint | Change |
 |------------|--------|
+| < 640px | Preview mode is single-pane; persistent sidebar/tree is hidden or replaced by a navigation control |
 | < 640px | Floating timestamp remains top-right inside the preview padding; content keeps enough top spacing to avoid collision |
-| 640-1024px | Sidebar remains fixed-width if present; floating timestamp stays top-right in the viewer |
+| < 640px | ToC opens from a compact control and must not cover the active reading position by default |
+| 640-1024px | Sidebar remains fixed-width only if the prose column keeps at least 48ch; otherwise use single-pane preview |
 | > 1024px | Two-pane layout; floating timestamp and sync status stay top-right in the viewer |
 
 ## Tokens used
@@ -194,6 +199,7 @@ Documents should not write date frontmatter automatically. For configured docume
 | frontmatter border | `--border` | Single border around disclosure |
 | frontmatter text | `--foreground`, `--muted-foreground` | Raw metadata and disclosure summary |
 | deleted state | `--destructive` | Deleted-file message |
+| markdown prose | `--foreground`, `--muted-foreground`, `--primary`, `--border`, `--code-*` | document body typography, links, tables, code |
 
 ## Classes used
 
@@ -206,6 +212,7 @@ Documents should not write date frontmatter automatically. For configured docume
 | semantic update state | `.document-update-indicator` proposed | Use when indicator styling is reused |
 | frontmatter disclosure | `.document-frontmatter` proposed | Native details/summary wrapper for raw metadata |
 | frontmatter code | `.document-frontmatter__code` proposed | Transparent inner code area; no nested panel |
+| markdown prose | `.prose.prose--document` proposed | `markdown-content.spec.md` reading variant |
 | semantic file state | `data-file-state` proposed | Mirrors `data-*` semantic variant guidance |
 
 ## Extension Notes

--- a/docs/design/surfaces/documents-view-navigation.spec.md
+++ b/docs/design/surfaces/documents-view-navigation.spec.md
@@ -180,8 +180,10 @@ DocumentsLayout
 
 | Breakpoint | Change |
 |------------|--------|
-| < 640px | header controls wrap to two rows; Favs and recent documents remain above tree |
-| 640-1024px | sidebar keeps fixed width; tree rows truncate long names |
+| < 640px | Documents route uses one primary pane at a time: navigation list or document preview |
+| < 640px | persistent sidebar/tree must not remain beside the markdown preview |
+| < 640px | header controls wrap to two rows in navigation mode; Favs and recent documents remain above tree |
+| 640-1024px | sidebar keeps fixed width only when preview content still has readable measure; tree rows truncate long names |
 | > 1024px | two-pane layout; sidebar sections remain visible above scroll area |
 
 ## Tokens used

--- a/docs/design/surfaces/markdown-content.mockups.md
+++ b/docs/design/surfaces/markdown-content.mockups.md
@@ -1,0 +1,124 @@
+# Markdown Content — Wireframe Schema
+
+Related spec: `markdown-content.spec.md`
+
+## Document Reading
+
+```wireloom
+window "Markdown Content — Document Reading":
+  panel:
+    row:
+      col 300:
+        text "Documents navigation" bold id="doc-nav"
+        text "See documents-view-navigation.mockups.md" muted
+      col fill:
+        row justify=end id="doc-meta":
+          text "Updated 1 week ago" muted size=small
+        text "# Project Documents" bold id="doc-h1"
+        text "This folder contains durable documentation for the TypeScript vocabulary extraction app." id="doc-p"
+        text "## Local Environment" bold id="doc-h2"
+        text "Use `.env` for local provider selection:"
+        section "Code block" id="doc-code":
+          text "LLM_PROVIDER=openrouter" size=small
+          text "OPENROUTER_API_KEY_FILE=/absolute/path/to/key" size=small
+        list:
+          item "`ARCHITECTURE.md` - target TypeScript app architecture."
+          item "`CLOUDFLARE_DEPLOYMENT.md` - deployment wrapper plan."
+
+annotation "Document prose uses a readable measure instead of filling every pixel" target="doc-h1" position=right
+annotation "Heading rhythm separates sections; paragraphs stay calm" target="doc-h2" position=right
+annotation "Code blocks are readable artifacts with horizontal scroll when needed" target="doc-code" position=right
+annotation "Navigation shell is not part of prose styling" target="doc-nav" position=bottom
+```
+
+## Ticket Reading
+
+```wireloom
+window "Markdown Content — Ticket Reading":
+  panel:
+    row:
+      text "MDT-042 • Fix login redirect" bold id="ticket-title"
+      spacer
+      button "×"
+    divider
+    row:
+      chip "Proposed"
+      chip "Medium"
+      chip "Bug"
+    divider
+    row justify=end:
+      text "Updated 2h ago" muted size=small id="ticket-meta"
+    text "### Problem" bold id="ticket-h"
+    text "Users are redirected to the board before session validation completes."
+    text "### Acceptance Criteria" bold
+    list:
+      item "[ ] Invalid sessions remain on login"
+      item "[ ] Valid sessions preserve the requested route"
+
+annotation "Ticket prose is denser than document prose but still owns markdown rhythm" target="ticket-h" position=right
+annotation "Timestamp must not overlap the first heading" target="ticket-meta" position=left
+```
+
+## Rich Markdown
+
+```wireloom
+window "Markdown Content — Rich Markdown":
+  panel:
+    text "## Implementation Notes" bold
+    text "Inline `code` should be visible without overpowering the paragraph." id="inline-code"
+    section "Table" id="table":
+      row:
+        text "Area" bold
+        text "Decision" bold
+      row:
+        text "Renderer"
+        text "markdown-it"
+      row:
+        text "Links"
+        text "SmartLink"
+    section "Blockquote" id="quote":
+      text "Use a quiet left border and muted text."
+    section "Mermaid / Wireloom artifact" id="diagram":
+      text "Large rendered artifacts scroll inside the prose area."
+
+annotation "Tables need padding, borders, header treatment, and horizontal overflow" target="table" position=right
+annotation "Blockquotes use tokenized border and muted text" target="quote" position=right
+annotation "Rendered diagrams keep their own artifact behavior" target="diagram" position=right
+annotation "Inline code should avoid global break-all behavior" target="inline-code" position=right
+```
+
+## Mobile Document Reading
+
+```wireloom
+window "Markdown Content — Mobile Document":
+  navbar:
+    leading:
+      button "Docs"
+    center:
+      text "README.md" bold
+    trailing:
+      button "ToC"
+  panel:
+    row justify=end:
+      text "Updated 1 week ago" muted size=small
+    text "# Project Documents" bold id="mobile-h1"
+    text "This folder contains durable documentation for the TypeScript vocabulary extraction app."
+    text "## Local Environment" bold
+    section "Code block" id="mobile-code":
+      text "LLM_PROVIDER=openrouter" size=small
+      text "OPENROUTER_API_KEY_FILE=/absolute/path/to/key" size=small
+
+annotation "Mobile viewer shows one primary pane; tree navigation moves behind a control" target="mobile-h1" position=bottom
+annotation "Long code scrolls inside the code block, not the page" target="mobile-code" position=top
+```
+
+## Annotations
+
+| Element | Token | Class | Notes |
+|---------|-------|-------|-------|
+| Document prose | `--foreground` | `.prose.prose--document` proposed | Reading-first rhythm and measure |
+| Ticket prose | `--foreground` | `.prose.prose--ticket` proposed | Modal density, compact headings |
+| Code block | `--code-bg`, `--code-fg`, `--border` | `.prose pre` | Scrollable artifact with tokenized color |
+| Inline code | `--code-bg`, `--code-fg` | `.prose :not(pre) > code` | Subtle emphasis, no letter-by-letter breaking |
+| Table | `--border`, `--muted` | `.prose table` | Padded cells and horizontal overflow |
+| Blockquote | `--border`, `--muted-foreground` | `.prose blockquote` | Quiet callout treatment |

--- a/docs/design/surfaces/markdown-content.mockups.md
+++ b/docs/design/surfaces/markdown-content.mockups.md
@@ -120,5 +120,5 @@ annotation "Long code scrolls inside the code block, not the page" target="mobil
 | Ticket prose | `--foreground` | `.prose.prose--ticket` proposed | Modal density, compact headings |
 | Code block | `--code-bg`, `--code-fg`, `--border` | `.prose pre` | Scrollable artifact with tokenized color |
 | Inline code | `--code-bg`, `--code-fg` | `.prose :not(pre) > code` | Subtle emphasis, no letter-by-letter breaking |
-| Table | `--border`, `--muted` | `.prose table` | Padded cells and horizontal overflow |
+| Table | `--border`, `--muted-foreground` | `.prose table` | Padded cells and horizontal overflow |
 | Blockquote | `--border`, `--muted-foreground` | `.prose blockquote` | Quiet callout treatment |

--- a/docs/design/surfaces/markdown-content.spec.md
+++ b/docs/design/surfaces/markdown-content.spec.md
@@ -1,0 +1,149 @@
+# Markdown Content
+
+Reusable typography and rich-content contract for rendered markdown in ticket and document surfaces.
+
+## Composition
+
+```text
+MarkdownContent
+├── ProseContainer
+│   ├── Headings
+│   ├── Paragraphs
+│   ├── Lists
+│   ├── TaskLists
+│   ├── Links
+│   ├── InlineCode
+│   ├── CodeBlocks
+│   ├── Tables
+│   ├── Blockquotes
+│   ├── HorizontalRules
+│   ├── MermaidDiagram
+│   └── WireloomFrame
+└── PostRenderEnhancements
+    ├── HeadingAnchors
+    ├── SmartLinks
+    ├── MermaidRenderer
+    └── LinkValidation
+```
+
+## Children
+
+| Child | Component | Spec | Conditional |
+|-------|-----------|------|-------------|
+| MarkdownContent | `src/components/MarkdownContent/index.tsx` | this spec | always for rendered markdown |
+| MarkdownViewer | `src/components/DocumentsView/MarkdownViewer.tsx` | `documents-view-file-updates.spec.md` | documents route |
+| TicketViewer | `src/components/TicketViewer/index.tsx` | `ticket-viewer.spec.md` | ticket modal |
+| TableOfContents | `src/components/shared/TableOfContents.tsx` | owning viewer spec | when headings exist |
+| SmartLink | `src/components/SmartLink` | — | when rendered markdown contains links |
+
+## Source files
+
+| Type | Path |
+|------|------|
+| Renderer | `src/components/MarkdownContent/index.tsx` |
+| Markdown pipeline | `src/components/MarkdownContent/useMarkdownProcessor.ts` |
+| Parser options | `src/components/MarkdownContent/useHtmlParser.ts` |
+| Prose CSS | `src/styles/prose.css` |
+| Base typography | `src/styles/base.css` |
+| Tokens | `src/styles/design-tokens.css` |
+
+## Variants
+
+| Variant | Consumer | Class Contract | Purpose |
+|---------|----------|----------------|---------|
+| document | Documents View | `.prose.prose--document` | Reading-first full markdown documents |
+| ticket | Ticket Viewer | `.prose.prose--ticket` | Dense ticket body inside modal |
+| compact | Small previews or constrained panes | `.prose.prose--compact` | Short excerpts without large section rhythm |
+
+Default `MarkdownContent` may keep the current base `prose` class, but every primary reading surface should opt into one of these variants.
+
+## Typography Rules
+
+- Body text uses Inter, `--foreground`, and a comfortable line height.
+- Document variant body text should read at 15-16px with line-height near 1.65.
+- Ticket variant body text should stay compact at 14-15px with line-height near 1.55-1.65.
+- Document reading width should be constrained around `72ch` while preserving full-width overflow handling for tables, diagrams, and code blocks.
+- Ticket content may use `max-w-none` because the modal width is already constrained.
+- Headings use the existing base weight family but own their markdown spacing inside `.prose`.
+- Heading rhythm should separate sections more than paragraphs do: larger top margin, smaller bottom margin.
+- First rendered heading has no top margin.
+- Paragraphs use consistent bottom spacing and should not rely on browser defaults.
+- Lists align with paragraphs, keep readable indentation, and preserve nested list hierarchy.
+- Task-list checkboxes align with the first text baseline and do not add extra left jitter.
+- Blockquotes use a left border, muted foreground, and no decorative quote marks.
+- Horizontal rules use `--border` and enough vertical margin to separate sections.
+
+## Rich Content Rules
+
+| Element | Rule |
+|---------|------|
+| Links | Use primary color, underline on hover/focus, and preserve SmartLink affordances |
+| Inline code | Subtle muted background, small border radius, no forced full-word breaking unless it would overflow |
+| Code blocks | Token-aware background, border, 8px radius or less, horizontal scroll, clear vertical rhythm |
+| Tables | Horizontal scroll wrapper behavior, visible cell padding, header tint, row dividers, no cramped default table layout |
+| Mermaid | Preserve existing diagram renderer; diagram surface should not inherit inline-code chrome |
+| Wireloom | Preserve existing rendered SVG behavior; pending/error states use theme tokens instead of hard-coded colors |
+| Images | Max width 100%, auto height, rounded only when the image is a content figure |
+
+## Layout
+
+- `.prose` owns markdown internals only; outer viewer components own pane padding and scrolling.
+- Documents View gives the prose block a readable measure and keeps large artifacts scrollable inside the viewer.
+- Ticket Viewer keeps the timestamp above or beside content without covering the first heading.
+- The Table of Contents is an external navigation affordance, not part of markdown flow.
+- Long links, file paths, and identifiers may wrap, but normal words should not break letter-by-letter.
+
+## States
+
+| State | Trigger | Visual Change |
+|-------|---------|---------------|
+| default document | selected markdown document renders | readable document rhythm, constrained measure, rich content styled |
+| default ticket | ticket body renders | compact rhythm inside modal content padding |
+| anchor hover | user hovers a heading with id | low-emphasis heading permalink appears |
+| focused link | keyboard focus on markdown link | visible focus ring or underline treatment using `--ring` |
+| wide table | table exceeds content width | horizontal scroll without page-level overflow |
+| long code block | code line exceeds content width | code block scrolls horizontally; prose column does not widen |
+| empty markdown | no body content | owning viewer renders its empty state; markdown surface renders nothing |
+| dark mode | root has `.dark` | all prose, code, table, and diagram fallback colors use theme tokens |
+
+## Responsive
+
+| Breakpoint | Change |
+|------------|--------|
+| < 640px | Document variant fills available viewer width; content panel must not sit beside a persistent tree |
+| < 640px | H1/H2 scale down enough to avoid overlap with viewer actions and timestamps |
+| < 640px | ToC opens as an overlay/sheet and must not cover the active paragraph by default |
+| 640-1024px | Documents may keep two panes only if the prose column remains at least 48ch |
+| > 1024px | Documents use readable measure with artifact overflow; ticket modal keeps compact rhythm |
+
+## Tokens used
+
+| Element | Token | Usage |
+|---------|-------|-------|
+| prose text | `--foreground` | body and headings |
+| secondary text | `--muted-foreground` | captions, blockquotes, helper text |
+| links | `--primary` | markdown links and heading anchors |
+| borders | `--border` | tables, blockquotes, code blocks, rules |
+| code background | `--code-bg` | inline and block code |
+| code text | `--code-fg` | inline and block code |
+| selection | `--code-selection` | code selection background |
+| focus | `--ring` | keyboard focus treatment |
+
+## Classes used
+
+| Element | Class | Source |
+|---------|-------|--------|
+| base prose | `.prose` | `src/styles/prose.css` |
+| document prose | `.prose--document` proposed | document reading variant |
+| ticket prose | `.prose--ticket` proposed | ticket modal reading variant |
+| compact prose | `.prose--compact` proposed | short preview variant |
+| heading anchor | `.header-anchor` | markdown-it-anchor output |
+| frontmatter disclosure | `.document-frontmatter` | Documents View file updates spec |
+| wireloom render | `.wireloom`, `.wireloom-pending`, `.wireloom-error` | existing markdown rendering |
+
+## Extension notes
+
+- Do not put global markdown spacing into `src/styles/base.css`; markdown rhythm belongs under `.prose`.
+- Do not style `.prose` with app-shell assumptions such as sidebar widths or modal padding.
+- Do not rely on hard-coded light colors in markdown fallback states; use design tokens.
+- If a new markdown consumer needs different density, add a named variant instead of overriding individual descendants inline.

--- a/docs/design/surfaces/ticket-viewer.mockups.md
+++ b/docs/design/surfaces/ticket-viewer.mockups.md
@@ -68,9 +68,9 @@ window "Ticket Viewer — No Sub-Docs":
     row:
       spacer
       text "Updated 2h ago" muted size=small id="tv-ns-timestamp"
-    text "## Problem" bold
+    text "### Problem" bold
     text "Users are redirected to..." muted
-    text "## Steps to Reproduce" bold
+    text "### Steps to Reproduce" bold
     text "1. Navigate to /login" muted
     text "2. Enter credentials" muted
 
@@ -162,9 +162,9 @@ window "Ticket Viewer — Mobile":
     row:
       spacer
       text "Updated 2h ago" muted size=small
-    text "## Problem" bold
+    text "### Problem" bold
     text "Users are redirected..." muted
-    text "## Steps" bold
+    text "### Steps" bold
     text "1. Navigate to /login" muted
 ```
 

--- a/docs/design/surfaces/ticket-viewer.mockups.md
+++ b/docs/design/surfaces/ticket-viewer.mockups.md
@@ -36,9 +36,9 @@ window "Ticket Viewer — With Sub-Docs":
         row:
           spacer
           text "Updated 2h ago" muted size=small id="tv-timestamp"
-        text "## Overview" bold id="tv-h2"
+        text "### Overview" bold id="tv-h2"
         text "This ticket covers..." muted
-        text "## Acceptance Criteria" bold
+        text "### Acceptance Criteria" bold
         text "- [ ] Users can log in" muted
         text "- [ ] Sessions persist" muted
 
@@ -47,6 +47,7 @@ annotation "Badge bar wraps if needed" target="tv-status" position=right
 annotation "Document tabs hidden if no subdocs" target="tv-doc-tabs" position=right
 annotation "RelativeTimestamp, absolute right-4 top-4" target="tv-timestamp" position=right
 annotation "ToC: collapsible sidebar" target="tv-toc-1" position=left
+annotation "Markdown body uses markdown-content.spec.md ticket variant" target="tv-h2" position=right
 ```
 
 ## No Sub-Documents (Main Content Only)

--- a/docs/design/surfaces/ticket-viewer.spec.md
+++ b/docs/design/surfaces/ticket-viewer.spec.md
@@ -109,6 +109,8 @@ Two horizontal bars, both with bottom border:
 - MarkdownContent uses the `ticket` typography variant from `markdown-content.spec.md`.
 - Ticket prose keeps compact rhythm: moderate section gaps, readable paragraphs, styled task lists, and scrollable artifacts.
 - Timestamp placement must not overlap the first rendered heading or first paragraph.
+- Ticket content must reserve `--ticket-content-timestamp-offset: 2.25rem` above the first rendered markdown child when `.relative-timestamp__floating` is visible.
+- If timestamp text wraps taller than one line, the reserved top inset becomes `max(2.25rem, timestamp height + 0.75rem)`.
 - Subdoc loading overlay: `absolute inset-0 z-10`, `bg-background/50`, pulsing "Loading…" text
 - Subdoc error: inline text, `text-destructive`, `role="alert"`
 
@@ -188,6 +190,7 @@ Three SSE event types handled:
 | modal | `.modal` | `MODALS.md` |
 | badge | `.badge[data-status="..."]` | `badge.css` |
 | markdown prose | `.prose.prose--ticket` proposed | `markdown-content.spec.md` |
+| timestamp offset | `--ticket-content-timestamp-offset` proposed | `2.25rem` minimum reserved top inset for floating timestamp |
 | tabs | `.ticket-document-tabs` | inline Tailwind |
 | tab trigger | Radix `data-[state=active]` | inline Tailwind |
 

--- a/docs/design/surfaces/ticket-viewer.spec.md
+++ b/docs/design/surfaces/ticket-viewer.spec.md
@@ -48,7 +48,7 @@ Modal[size="xl"]
 | TableOfContents | `src/components/shared/TableOfContents.tsx` | — | always (extracts from content) |
 | CompactTicketHeader | `src/components/TicketViewer/CompactTicketHeader.tsx` | — | when ticket exists |
 | TicketDocumentTabs | `src/components/TicketViewer/TicketDocumentTabs.tsx` | — | when `subdocuments.length > 0` |
-| MarkdownContent | `src/components/MarkdownContent.tsx` | — | always (renders main or subdoc content) |
+| MarkdownContent | `src/components/MarkdownContent/index.tsx` | `markdown-content.spec.md` | always (renders main or subdoc content) |
 | RelativeTimestamp | `src/components/shared/RelativeTimestamp.tsx` | — | in content area |
 | StatusBadge | `src/components/Badge/StatusBadge.tsx` | — | always in header |
 | PriorityBadge | `src/components/Badge/PriorityBadge.tsx` | — | always in header |
@@ -106,6 +106,9 @@ Two horizontal bars, both with bottom border:
 - Padding: `px-4 py-4 sm:px-5`
 - RelativeTimestamp: `absolute right-4 top-4 z-[1] sm:right-5`
 - MarkdownContent: receives `headerLevelStart={3}` (renders H1 as H3)
+- MarkdownContent uses the `ticket` typography variant from `markdown-content.spec.md`.
+- Ticket prose keeps compact rhythm: moderate section gaps, readable paragraphs, styled task lists, and scrollable artifacts.
+- Timestamp placement must not overlap the first rendered heading or first paragraph.
 - Subdoc loading overlay: `absolute inset-0 z-10`, `bg-background/50`, pulsing "Loading…" text
 - Subdoc error: inline text, `text-destructive`, `role="alert"`
 
@@ -176,6 +179,7 @@ Three SSE event types handled:
 | muted-foreground | `--muted-foreground` | close button, timestamps, loading text |
 | destructive | `--destructive` | subdoc error text |
 | badge colors | `badge.css` data attributes | all badge variants |
+| markdown prose | `--foreground`, `--muted-foreground`, `--primary`, `--border`, `--code-*` | ticket body typography, links, tables, code |
 
 ## Classes used
 
@@ -183,6 +187,7 @@ Three SSE event types handled:
 |---------|-------|--------|
 | modal | `.modal` | `MODALS.md` |
 | badge | `.badge[data-status="..."]` | `badge.css` |
+| markdown prose | `.prose.prose--ticket` proposed | `markdown-content.spec.md` |
 | tabs | `.ticket-document-tabs` | inline Tailwind |
 | tab trigger | Radix `data-[state=active]` | inline Tailwind |
 


### PR DESCRIPTION
## Summary
- add a Markdown Content design spec and mockups for document, ticket, compact prose variants
- link Documents View and Ticket Viewer specs to the shared markdown typography contract
- create MDT-173 as the implementation plan for delivering the typography work

## Verification
- wireloom blocks validated for markdown-content, ticket-viewer, and documents-view-file-updates mockups
- git diff --check passed for the scoped docs changes
- pre-commit hooks passed during commit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive design specifications for markdown typography variants optimized for different reading surfaces with improved spacing and readability
  * Updated responsive design requirements to enhance mobile viewing with better layout separation and prevent overlapping UI elements

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/andkirby/markdown-ticket/pull/12?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->